### PR TITLE
P7packages composer

### DIFF
--- a/.github/actions/split-monorepo/action.yaml
+++ b/.github/actions/split-monorepo/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: 'Force push'
     required: false
     default: 'false'
+  push-tags:
+    description: 'Push tags'
+    required: false
+    default: 'false'
   gh-token:
     required: true
     description: "GitHub token"
@@ -28,4 +32,4 @@ runs:
       shell: "bash"
       run: |
         git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
-        bash ${{github.action_path}}/split-repositories.sh "${{ inputs.gh-token }}" "${{ inputs.package }}" ${{ inputs.organization }} "${{ github.ref_name }}" ${{ inputs.force == 'true' }}
+        bash ${{github.action_path}}/split-repositories.sh "${{ inputs.gh-token }}" "${{ inputs.package }}" ${{ inputs.organization }} "${{ github.ref_name }}" ${{ inputs.force == 'true' }} ${{ inputs.push-tags == 'true' }}

--- a/.github/actions/split-monorepo/split-repositories.sh
+++ b/.github/actions/split-monorepo/split-repositories.sh
@@ -7,6 +7,7 @@ PACKAGE=$2
 ORGANIZATION=$3
 BRANCH=$4
 FORCE=${5:-false}
+PUSH_TAG=${6:-false}
 
 TMP="tmp_split/${RANDOM}"
 URL="https://${GH_TOKEN}@github.com/${ORGANIZATION}/${PACKAGE}"
@@ -19,10 +20,12 @@ echo "Monorepo Split – ${PACKAGE}"
 
 echo "Init environment"
 
+PUSH_OPTS=""
 if [[ "$FORCE" == true ]]; then
-  PUSH_OPTS="--force"
-else
-  PUSH_OPTS="--tags"
+  PUSH_OPTS="${PUSH_OPTS} --force"
+fi
+if [[ "$PUSH_TAG" == true ]]; then
+  PUSH_OPTS="${PUSH_OPTS} --tags"
 fi
 
 cd ${DIR_PWD}

--- a/.github/workflows/composer-validate.yaml
+++ b/.github/workflows/composer-validate.yaml
@@ -45,5 +45,4 @@ jobs:
       - name: Composer validate
         if: env.GIT_DIFF && env.MATCHED_FILES
         run: |
-          composer install --no-progress
           composer validate

--- a/.github/workflows/monorepo_release.yml
+++ b/.github/workflows/monorepo_release.yml
@@ -1,4 +1,5 @@
 name: Monorepo release
+run-name: Monorepo release - ${{ inputs.version }} version
 
 on:
   workflow_dispatch:
@@ -55,5 +56,17 @@ jobs:
       - name: Composer
         uses: ramsey/composer-install@v2
 
+      - name: Stage Check
+        id: stage
+        shell: bash
+        run: |
+          if [ "${{ inputs.version }}" == 'patch' ]; then
+            echo "stage=patch" >> $GITHUB_OUTPUT;
+          elif [ "${{ inputs.version }}" == 'minor' ]; then
+            echo "stage=release" >> $GITHUB_OUTPUT;
+          elif [ "${{ inputs.version }}" == 'major' ]; then
+            echo "stage=release" >> $GITHUB_OUTPUT;
+          fi
+
       - name: Release
-        run: vendor/bin/monorepo-builder release ${{ inputs.version }}
+        run: vendor/bin/monorepo-builder release ${{ inputs.version }} --stage ${{ steps.stage.outputs.stage}}

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      push-tags:
+        description: 'push tags'
+        required: false
+        type: boolean
+        default: false
     secrets:
       gh-token:
         required: true
@@ -64,4 +69,5 @@ jobs:
           organization: ${{ inputs.organization }}
           package: ${{ inputs.package }}
           force: ${{ inputs.force }}
+          push-tags: ${{ inputs.push-tags }}
           gh-token: ${{ secrets.gh-token }}

--- a/workflow-templates/p7-monorepo-split-with-dispatch.yaml
+++ b/workflow-templates/p7-monorepo-split-with-dispatch.yaml
@@ -30,5 +30,6 @@ jobs:
       package: ${{ matrix.package }}
       organization: "peckadesign"
       force: ${{ inputs.force == 'true' }}
+      push-tags:  ${{ github.ref != 'refs/heads/master' }}
     secrets:
       gh-token: # GITHUB Token

--- a/workflow-templates/p7-monorepo-split.yaml
+++ b/workflow-templates/p7-monorepo-split.yaml
@@ -24,5 +24,6 @@ jobs:
     with:
       package: ${{ matrix.package }}
       organization: "peckadesign"
+      push-tags:  ${{ github.ref != 'refs/heads/master' }}
     secrets:
       gh-token: # GITHUB Token


### PR DESCRIPTION
- peckadesign/p7packages#146 - Při splitování se tagy pushují jen pro v* větve (ne master/main),
  - split-repositories.sh má volitelné pushování tagů,
  - monorepo_release umí rozpoznat "stage"
- peckadesign/p7packages#217 - Pro ověření composer validate není potřeba composer install