### PR TITLE
peckadesign/p7packages#217 - Pro klonování repozitáře git clone je použit přepínač `--no-local`

### DIFF
--- a/.github/actions/split-monorepo/split-repositories.sh
+++ b/.github/actions/split-monorepo/split-repositories.sh
@@ -32,14 +32,14 @@ cd ${DIR_PWD}
 echo "mkdir -p ${DIR_PWD}/${TMP}/${PACKAGE}"
 mkdir -p ${DIR_PWD}/${TMP}/${PACKAGE}
 
-echo "git clone --bare .git ${DIR_PWD}/${TMP}/${PACKAGE}"
-git clone --bare .git ${DIR_PWD}/${TMP}/${PACKAGE}
+echo "git clone --bare --no-local .git ${DIR_PWD}/${TMP}/${PACKAGE}"
+git clone --bare --no-local .git ${DIR_PWD}/${TMP}/${PACKAGE}
 
 echo "cd ${DIR_PWD}/${TMP}/${PACKAGE}"
 cd ${DIR_PWD}/${TMP}/${PACKAGE}
 
-echo "git filter-repo --subdirectory-filter packages/${PACKAGE} --force"
-git filter-repo --subdirectory-filter packages/${PACKAGE} --force
+echo "git filter-repo --subdirectory-filter packages/${PACKAGE}"
+git filter-repo --subdirectory-filter packages/${PACKAGE}
 
 echo "git push github.com/${ORGANIZATION}/${PACKAGE} ${BRANCH} --dry-run ${PUSH_OPTS} --verbose"
 git push "${URL}.git" ${BRANCH} --dry-run ${PUSH_OPTS} --verbose

--- a/workflow-templates/p7-monorepo-split-with-dispatch.yaml
+++ b/workflow-templates/p7-monorepo-split-with-dispatch.yaml
@@ -11,6 +11,13 @@ on:
         options:
           - 'true'
           - 'false'
+      package:
+        description: 'Název package'
+        required: true
+        type: choice
+        options: #Je potřeba definovat konkrétní balíček pro které se spouští split
+          - 'package-sdk'
+          - 'package-admin'
 
 concurrency:
   group: split_monorepo-${{ github.ref_name }}-${{ github.ref }}
@@ -20,14 +27,8 @@ jobs:
   split-branch:
     uses: peckadesign/.github/.github/workflows/split_monorepo.yaml@v1
     name: Split
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - package-data-exchange
-          - package-sdk
     with:
-      package: ${{ matrix.package }}
+      package:  ${{ inputs.package }}
       organization: "peckadesign"
       force: ${{ inputs.force == 'true' }}
       push-tags:  ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
- peckadesign/p7packages#217 - Pro klonování repozitáře git clone je použit přepínač `--no-local` https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---local aby se zamezlo nutnosti použít příkaz `git filter-repo` s příznakem `--force`
- Upravena příkla workflow pro splitování, aby pro ruční spuštění splitu bylo povinné zadání příslušného package. Jee to z důvodu, aby se nespouštěl split pro všechny balíčky, když to ve většině případů bude potřeba jen pro jeden)