### PR TITLE
Monorepo release nově neinstaluje composer s  --ignore-platform-reqs

### DIFF
--- a/.github/workflows/composer-validate.yaml
+++ b/.github/workflows/composer-validate.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   composer:
     name: "Composer validate"
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, k8s-gnome-fast ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/p7_monorepo_release.yaml
+++ b/.github/workflows/p7_monorepo_release.yaml
@@ -8,6 +8,16 @@ on:
         description: 'Version'
         required: true
         type: string
+      php_version:
+        description: 'PHP Version'
+        default: '8.1'
+        required: false
+        type: string
+      extensions:
+        description: 'PHP extensions'
+        default: ''
+        required: false
+        type: string
     secrets:
       gh-token:
         required: true
@@ -29,14 +39,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: "${{ inputs.php_version }}"
+          extensions: "${{ inputs.extensions }}"
         env:
           GITHUB_TOKEN: ${{ secrets.gh-token }}
 
       - name: Composer
         uses: ramsey/composer-install@v2
-        with:
-          composer-options: "--ignore-platform-reqs"
 
       - name: Stage Check
         id: stage


### PR DESCRIPTION
Monorepo release nově neinstaluje composer s  --ignore-platform-reqs, je potřeba předat php extensiony v nastavení github akce