### PR TITLE
downgrade ramsey/composer-install na v2 a actions/checkout na v4

### DIFF
--- a/.github/actions/p7-monorepo-release/action.yaml
+++ b/.github/actions/p7-monorepo-release/action.yaml
@@ -38,7 +38,7 @@ runs:
           *) echo "::error::Unknown version type: $VERSION"; exit 1 ;;
         esac
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ inputs.gh-token }}
@@ -64,7 +64,7 @@ runs:
         composer config -- github-oauth.github.com "${{ inputs.gh-token }}"
 
     - name: Composer
-      uses: ramsey/composer-install@v3
+      uses: ramsey/composer-install@v2
       with:
         composer-options: "--optimize-autoloader"
       env:


### PR DESCRIPTION
- ramsey/composer-install je poníženo zpět na v2, protože runnery ještě nemají povýšenou verzi node.
- actions/checkout ponížen znovu na v4, protože runneři musejí být na stejné nebo vyšší verzi