### PR TITLE
autentizace se nastavuje pouze v kroku Composer Install,

### DIFF
--- a/.github/actions/p7-monorepo-release/action.yaml
+++ b/.github/actions/p7-monorepo-release/action.yaml
@@ -69,26 +69,18 @@ runs:
           git config --global user.email "action@github.com"
         fi
 
-    - name: Configure Git auth for GitHub (fallback na git clone)
-      shell: bash
-      run: |
-        # 1) Composer: přidej HTTP Basic (vedle stávajícího github-oauth)
-        printf '%s\n' 'COMPOSER_AUTH={"github-oauth":{"github.com":"${{ inputs.gh-token }}"},"http-basic":{"github.com":{"username":"x-access-token","password":"${{ inputs.gh-token }}"}},"github-protocols":["https"]}' >> "$GITHUB_ENV"
-        # 2) it: přesměruj https/ssh GitHub URL na https s tokenem - preferuj lokálně, pokud jsme v GIT repo
-        if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-          git config --local url."https://x-access-token:${{ inputs.gh-token }}@github.com/".insteadOf "https://github.com/"
-          git config --local url."https://x-access-token:${{ inputs.gh-token }}@github.com/".insteadOf "git@github.com:"
-          git config --local url."https://x-access-token:${{ inputs.gh-token }}@github.com/".insteadOf "ssh://git@github.com/"
-        else
-          git config --global url."https://x-access-token:${{ inputs.gh-token }}@github.com/".insteadOf "https://github.com/"
-          git config --global url."https://x-access-token:${{ inputs.gh-token }}@github.com/".insteadOf "git@github.com:"
-          git config --global url."https://x-access-token:${{ inputs.gh-token }}@github.com/".insteadOf "ssh://git@github.com/"
-        fi
-
     - name: Composer Install
       uses: ramsey/composer-install@v2
       with:
         composer-options: "--optimize-autoloader --prefer-dist"
+      env:
+        # POZOR: Nepředáváme 'github-token', aby se to nebilo s COMPOSER_AUTH.
+        COMPOSER_AUTH: >-
+          {
+            "github-oauth":{"github.com":"${{ inputs.gh-token }}"},
+            "http-basic":{"github.com":{"username":"x-access-token","password":"${{ inputs.gh-token }}"}},
+            "github-protocols":["https"]
+          }
 
     - name: Release
       shell: bash


### PR DESCRIPTION
autentizace se nastavuje pouze v kroku Composer Install,
- odebírám přesměruj https/ssh GitHub URL na https s tokenem, zatím nevyužito